### PR TITLE
[Fixes #1] When no active project is determined, avoid NRE in build output by returning string.Empty.

### DIFF
--- a/EditorExtensions/Helpers/ProjectHelpers.cs
+++ b/EditorExtensions/Helpers/ProjectHelpers.cs
@@ -31,8 +31,13 @@ namespace MadsKristensen.EditorExtensions
                 {
                     activeProject = activeSolutionProjects.GetValue(0) as Project;
                 }
-
-                return activeProject.Properties.Item("FullPath").Value.ToString();
+                
+                if (activeProject == null)
+                {
+                    return string.Empty;
+                }
+                
+                return activeProject.Properties.Item("FullPath").Value.ToString();                
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
`stringEmpty` seems to be the appropriate value to return when no project can be determined.
