### PR TITLE
Enable strict math support for LESS Compiler

### DIFF
--- a/EditorExtensions/Margin/LessCompiler.cs
+++ b/EditorExtensions/Margin/LessCompiler.cs
@@ -22,6 +22,10 @@ namespace MadsKristensen.EditorExtensions
             start.WindowStyle = ProcessWindowStyle.Hidden;
             start.CreateNoWindow = true;
             start.Arguments = "//nologo //s \"" + GetExecutablePath() + "\" \"" + fileName + "\" \"" + output + "\"";
+            if (WESettings.GetBoolean(WESettings.Keys.LessStrictMath))
+            {
+                start.Arguments += " --strictMath";
+            }
             start.EnvironmentVariables["output"] = output;
             start.EnvironmentVariables["fileName"] = fileName;
             start.UseShellExecute = false;

--- a/EditorExtensions/Options/Less.cs
+++ b/EditorExtensions/Options/Less.cs
@@ -17,6 +17,7 @@ namespace MadsKristensen.EditorExtensions
             Settings.SetValue(WESettings.Keys.LessMinify, LessMinify);
             Settings.SetValue(WESettings.Keys.LessCompileOnBuild, LessCompileOnBuild);
             Settings.SetValue(WESettings.Keys.LessCompileToFolder, LessCompileToFolder);
+            Settings.SetValue(WESettings.Keys.LessStrictMath, LessStrictMath);
 
             Settings.Save();
         }
@@ -28,6 +29,7 @@ namespace MadsKristensen.EditorExtensions
             LessMinify = WESettings.GetBoolean(WESettings.Keys.LessMinify);
             LessCompileOnBuild = WESettings.GetBoolean(WESettings.Keys.LessCompileOnBuild);
             LessCompileToFolder = WESettings.GetBoolean(WESettings.Keys.LessCompileToFolder);
+            LessStrictMath = WESettings.GetBoolean(WESettings.Keys.LessStrictMath);
         }
 
         [LocDisplayName("Generate CSS file on save")]
@@ -54,5 +56,10 @@ namespace MadsKristensen.EditorExtensions
         [Description("Compiles all LESS files into a folder called 'css' in the same directory as the .less file")]
         [Category("LESS")]
         public bool LessCompileToFolder { get; set; }
+
+        [LocDisplayName("Use strict math")]
+        [Description("Set's the strictMath option to true when compiling LESS to CSS")]
+        [Category("LESS")]
+        public bool LessStrictMath { get; set; }
     }
 }

--- a/EditorExtensions/Options/WebEssentialsSettings.cs
+++ b/EditorExtensions/Options/WebEssentialsSettings.cs
@@ -16,6 +16,7 @@ namespace MadsKristensen.EditorExtensions
             public const string LessMinify = "LessMinify";
             public const string LessCompileOnBuild = "LessCompileOnBuild";
             public const string LessCompileToFolder = "LessCompileToFolder";
+            public const string LessStrictMath = "LessStrictMath";
 
             // SCSS
             public const string GenerateCssFileFromScss = "ScssGenerateCssFile";

--- a/EditorExtensions/Resources/Scripts/lessc.wsf
+++ b/EditorExtensions/Resources/Scripts/lessc.wsf
@@ -120,12 +120,13 @@ Licensed under the Apache 2.0 License.
         for (var i = 0; i < WScript.Arguments.Length; i++) {
             var arg = WScript.Arguments.Item(i);
             // Handle "-switch" and "--switch"
+            var key = i;
             var match = arg.match(/^--?([a-z][0-9a-z-]*)$/i);
             if (match) {
-                i = match[1];
+                key = match[1];
                 arg = true;
             }
-            args[i] = arg;
+            args[key] = arg;
         }
 
         input = args[0];

--- a/EditorExtensions/Resources/Scripts/lessc.wsf
+++ b/EditorExtensions/Resources/Scripts/lessc.wsf
@@ -206,7 +206,8 @@ Licensed under the Apache 2.0 License.
                     }
                     else {
                         var css = tree.toCSS({
-                            compress: args.compress
+                            compress: args.compress,
+                            strictMath: !!args.strictMath
                         });
                         if (output) {
                             if (fso.FileExists(output)) {


### PR DESCRIPTION
This adds an option to enable strict math when compiling LESS to CSS.  This change was inspired by [this question on stackoverflow.com](http://stackoverflow.com/q/19642171/361684).
