### PR TITLE
UTF-8 BOM option (default=false)

### DIFF
--- a/EditorExtensions/Commands/Css/CssExtractToFileCommandTarget.cs
+++ b/EditorExtensions/Commands/Css/CssExtractToFileCommandTarget.cs
@@ -51,9 +51,10 @@ namespace MadsKristensen.EditorExtensions
 
                 if (!File.Exists(fileName))
                 {
-                    _dte.UndoContext.Open("Extract to file...");
+                    bool useBom = WESettings.GetBoolean(WESettings.Keys.UseBom);
 
-                    using (StreamWriter writer = new StreamWriter(fileName, false, new UTF8Encoding(true)))
+                    _dte.UndoContext.Open("Extract to file...");
+                    using (StreamWriter writer = new StreamWriter(fileName, false, new UTF8Encoding(useBom)))
                     {
                         writer.Write(content);
                     }

--- a/EditorExtensions/Commands/Css/CssSaveListener.cs
+++ b/EditorExtensions/Commands/Css/CssSaveListener.cs
@@ -50,10 +50,11 @@ namespace MadsKristensen.EditorExtensions
 
             try
             {
+                bool useBom    = WESettings.GetBoolean(WESettings.Keys.UseBom);
                 string content = MinifyFileMenu.MinifyString(".css", File.ReadAllText(file));
 
                 ProjectHelpers.CheckOutFileFromSourceControl(minFile);
-                using (StreamWriter writer = new StreamWriter(minFile, false, new UTF8Encoding(true)))
+                using (StreamWriter writer = new StreamWriter(minFile, false, new UTF8Encoding(useBom)))
                 {
                     writer.Write(content);
                 }

--- a/EditorExtensions/Commands/JavaScript/JavaScriptSaveListener.cs
+++ b/EditorExtensions/Commands/JavaScript/JavaScriptSaveListener.cs
@@ -77,10 +77,11 @@ namespace MadsKristensen.EditorExtensions
 
         private static void MinifyFileWithSourceMap(string file, string minFile, CodeSettings settings, bool isBundle)
         {
+            bool useBom    = WESettings.GetBoolean(WESettings.Keys.UseBom);
             string mapPath = minFile + ".map";
-            ProjectHelpers.CheckOutFileFromSourceControl(mapPath);
 
-            using (TextWriter writer = new StreamWriter(mapPath, false, new UTF8Encoding(false)))
+            ProjectHelpers.CheckOutFileFromSourceControl(mapPath);
+            using (TextWriter writer = new StreamWriter(mapPath, false, new UTF8Encoding(useBom)))
             using (V3SourceMap sourceMap = new V3SourceMap(writer))
             {
                 settings.SymbolsMap = sourceMap;
@@ -115,8 +116,10 @@ namespace MadsKristensen.EditorExtensions
                 content += "\r\n/*\r\n//# sourceMappingURL=" + Path.GetFileName(minFile) + ".map\r\n*/";
             }
 
+            bool useBom = WESettings.GetBoolean(WESettings.Keys.UseBom);
+
             ProjectHelpers.CheckOutFileFromSourceControl(minFile);
-            using (StreamWriter writer = new StreamWriter(minFile, false, new UTF8Encoding(true)))
+            using (StreamWriter writer = new StreamWriter(minFile, false, new UTF8Encoding(useBom)))
             {
                 writer.Write(content);
             }

--- a/EditorExtensions/Margin/CoffeeScriptMargin.cs
+++ b/EditorExtensions/Margin/CoffeeScriptMargin.cs
@@ -70,10 +70,11 @@ namespace MadsKristensen.EditorExtensions
         {
             _projectFileStep++;
             string file = GetCompiledFileName(e.State, ".js", UseCompiledFolder);
+            bool useBom = WESettings.GetBoolean(WESettings.Keys.UseBom);
 
             ProjectHelpers.CheckOutFileFromSourceControl(file);
 
-            using (StreamWriter writer = new StreamWriter(file, false, new UTF8Encoding(true)))
+            using (StreamWriter writer = new StreamWriter(file, false, new UTF8Encoding(useBom)))
             {
                 writer.Write(e.Result);
             }
@@ -140,12 +141,13 @@ namespace MadsKristensen.EditorExtensions
         {
             if (WESettings.GetBoolean(WESettings.Keys.CoffeeScriptMinify))
             {
+                bool useBom    = WESettings.GetBoolean(WESettings.Keys.UseBom);
                 string content = MinifyFileMenu.MinifyString(".js", source);
                 string minFile = GetCompiledFileName(fileName, ".min.js", UseCompiledFolder);//fileName.Replace(".coffee", ".min.js");
                 bool fileExist = File.Exists(minFile);
 
                 ProjectHelpers.CheckOutFileFromSourceControl(minFile);
-                using (StreamWriter writer = new StreamWriter(minFile, false, new UTF8Encoding(true)))
+                using (StreamWriter writer = new StreamWriter(minFile, false, new UTF8Encoding(useBom)))
                 {
                     writer.Write(content);
                 }

--- a/EditorExtensions/Margin/LessMargin.cs
+++ b/EditorExtensions/Margin/LessMargin.cs
@@ -50,15 +50,16 @@ namespace MadsKristensen.EditorExtensions
         }
 
         public override void MinifyFile(string fileName, string source)
-        {
+        {            
             if (WESettings.GetBoolean(WESettings.Keys.LessMinify) && !Path.GetFileName(fileName).StartsWith("_"))
             {
+                bool useBom    = WESettings.GetBoolean(WESettings.Keys.UseBom);
                 string content = MinifyFileMenu.MinifyString(".css", source);
                 string minFile = GetCompiledFileName(fileName, ".min.css", UseCompiledFolder);// fileName.Replace(".less", ".min.css");
                 bool fileExist = File.Exists(minFile);
 
                 ProjectHelpers.CheckOutFileFromSourceControl(minFile);
-                using (StreamWriter writer = new StreamWriter(minFile, false, new UTF8Encoding(true)))
+                using (StreamWriter writer = new StreamWriter(minFile, false, new UTF8Encoding(useBom)))
                 {
                     writer.Write(content);
                 }

--- a/EditorExtensions/Margin/LessProjectCompiler.cs
+++ b/EditorExtensions/Margin/LessProjectCompiler.cs
@@ -65,7 +65,8 @@ namespace MadsKristensen.EditorExtensions
                         ProjectHelpers.CheckOutFileFromSourceControl(cssFileName);
                         try
                         {
-                            using (StreamWriter writer = new StreamWriter(cssFileName, false, new UTF8Encoding(true)))
+                            bool useBom = WESettings.GetBoolean(WESettings.Keys.UseBom);
+                            using (StreamWriter writer = new StreamWriter(cssFileName, false, new UTF8Encoding(useBom)))
                             {
                                 writer.Write(result.Result);
                             }
@@ -100,9 +101,10 @@ namespace MadsKristensen.EditorExtensions
                 if (old != content)
                 {
                     bool fileExist = File.Exists(minFile);
+                    bool useBom    = WESettings.GetBoolean(WESettings.Keys.UseBom);
 
                     ProjectHelpers.CheckOutFileFromSourceControl(minFile);
-                    using (StreamWriter writer = new StreamWriter(minFile, false, new UTF8Encoding(true)))
+                    using (StreamWriter writer = new StreamWriter(minFile, false, new UTF8Encoding(useBom)))
                     {
                         writer.Write(content);
                     }

--- a/EditorExtensions/Margin/MarginBase.cs
+++ b/EditorExtensions/Margin/MarginBase.cs
@@ -302,7 +302,8 @@ namespace MadsKristensen.EditorExtensions
             {
                 if (fileExist || (!fileExist && CanWriteToDisk(content)))
                 {
-                    using (StreamWriter writer = new StreamWriter(fileName, false, new UTF8Encoding(true)))
+                    bool useBom = WESettings.GetBoolean(WESettings.Keys.UseBom);
+                    using (StreamWriter writer = new StreamWriter(fileName, false, new UTF8Encoding(useBom)))
                     {
                         writer.Write(content);
                         fileWritten = true;

--- a/EditorExtensions/Margin/MarkdownMargin.cs
+++ b/EditorExtensions/Margin/MarkdownMargin.cs
@@ -70,8 +70,9 @@ namespace MadsKristensen.EditorExtensions
         public static void CreateStylesheet()
         {
             string file = Path.Combine(ProjectHelpers.GetSolutionFolderPath(), _stylesheet);
+            bool useBom = WESettings.GetBoolean(WESettings.Keys.UseBom);
 
-            using (StreamWriter writer = new StreamWriter(file, false, new UTF8Encoding(true)))
+            using (StreamWriter writer = new StreamWriter(file, false, new UTF8Encoding(useBom)))
             {
                 writer.Write("body { background: yellow; }");
             }

--- a/EditorExtensions/MenuItems/BundleFiles.cs
+++ b/EditorExtensions/MenuItems/BundleFiles.cs
@@ -327,8 +327,10 @@ namespace MadsKristensen.EditorExtensions
 
             if (!File.Exists(bundlePath) || File.ReadAllText(bundlePath) != sb.ToString())
             {
+                bool useBom = WESettings.GetBoolean(WESettings.Keys.UseBom);
+
                 ProjectHelpers.CheckOutFileFromSourceControl(bundlePath);
-                using (StreamWriter writer = new StreamWriter(bundlePath, false, new UTF8Encoding(true)))
+                using (StreamWriter writer = new StreamWriter(bundlePath, false, new UTF8Encoding(useBom)))
                 {
                     writer.Write(sb.ToString());
                     Logger.Log("Updating bundle: " + Path.GetFileName(bundlePath));
@@ -361,10 +363,10 @@ namespace MadsKristensen.EditorExtensions
             else if (extension.Equals(".css", StringComparison.OrdinalIgnoreCase))
             {
                 string minContent = MinifyFileMenu.MinifyString(extension, content);
+                bool useBom       = WESettings.GetBoolean(WESettings.Keys.UseBom);
 
                 ProjectHelpers.CheckOutFileFromSourceControl(minPath);
-
-                using (StreamWriter writer = new StreamWriter(minPath, false, new UTF8Encoding(true)))
+                using (StreamWriter writer = new StreamWriter(minPath, false, new UTF8Encoding(useBom)))
                 {
                     writer.Write(minContent);
                 }

--- a/EditorExtensions/Options/General.cs
+++ b/EditorExtensions/Options/General.cs
@@ -37,6 +37,11 @@ namespace MadsKristensen.EditorExtensions
         [Category("Misc")]
         public bool EnableHtmlZenCoding { get; set; }
 
+        [LocDisplayName("Save UTF-8 files with BOM")]
+        [Description("Whether to use BOM « byte-order-mark » when saving UTF-8 files")]
+        [Category("Misc")]
+        public bool UseBom { get; set; }
+
         [LocDisplayName("Keep important comments")]
         [Description("Don't strip important comments when minifying JS and CSS. Important comments follows this pattern: /*! text */")]
         [Category("Minification")]

--- a/EditorExtensions/Options/ProjectSettingsStore.cs
+++ b/EditorExtensions/Options/ProjectSettingsStore.cs
@@ -289,6 +289,7 @@ namespace MadsKristensen.EditorExtensions
             // MISC
             dic.Add(Keys.ShowBrowserTooltip, true);
             dic.Add(Keys.WrapCoffeeScriptClosure, true);
+            dic.Add(Keys.UseBom, false);
 
             // Minification
             dic.Add(Keys.EnableCssMinification, true);

--- a/EditorExtensions/Options/WebEssentialsSettings.cs
+++ b/EditorExtensions/Options/WebEssentialsSettings.cs
@@ -9,6 +9,7 @@ namespace MadsKristensen.EditorExtensions
             public const string EnableHtmlZenCoding = "HtmlEnableZenCoding";
             public const string EnableMustache = "HtmlEnableMustache";
             public const string KeepImportantComments = "KeepImportantComments";
+            public const string UseBom = "UseBom";
 
             // LESS
             public const string GenerateCssFileFromLess = "LessGenerateCssFile";


### PR DESCRIPTION
Option to save with BOM or not ..all files where being saved with BOM, which is now set to false by default. BOM causes endless problems with other open-source projects, and apparently even with older IE versions.

Actually only MinifyFileWithSourceMap() was using BOM=false, everything else was using BOM=true

..double check. I simply applied the choice to anywhere new UTF8Encoding() was being called to be sure other file types (coffee ..) benefit from this too.
