### PR TITLE
Compile & Min LESS when output files don't exist

### DIFF
--- a/EditorExtensions/Margin/LessProjectCompiler.cs
+++ b/EditorExtensions/Margin/LessProjectCompiler.cs
@@ -38,15 +38,6 @@ namespace MadsKristensen.EditorExtensions
             if (Path.GetFileName(fileName).StartsWith("_"))
                 return false;
 
-            string minFile = MarginBase.GetCompiledFileName(fileName, ".min.css", WESettings.GetBoolean(WESettings.Keys.LessCompileToFolder));
-            if (File.Exists(minFile) && WESettings.GetBoolean(WESettings.Keys.LessMinify))
-                return true;
-
-            string cssFile = MarginBase.GetCompiledFileName(fileName, ".css", WESettings.GetBoolean(WESettings.Keys.LessCompileToFolder));
-            if (!File.Exists(cssFile))
-                return false;
-
-
             return true;
         }
 
@@ -56,25 +47,36 @@ namespace MadsKristensen.EditorExtensions
             {
                 string cssFileName = MarginBase.GetCompiledFileName(result.FileName, ".css", WESettings.GetBoolean(WESettings.Keys.LessCompileToFolder));// result.FileName.Replace(".less", ".css");
 
-                if (File.Exists(cssFileName))
+                bool cssFileExists = File.Exists(cssFileName);
+                string old = string.Empty;
+                if (cssFileExists)
                 {
-                    string old = File.ReadAllText(cssFileName);
+                    old = File.ReadAllText(cssFileName);
+                }
 
-                    if (old != result.Result)
-                    {
+                if (!cssFileExists || old != result.Result)
+                {
+                    if (cssFileExists)
+                    {                            
                         ProjectHelpers.CheckOutFileFromSourceControl(cssFileName);
-                        try
+                    }
+
+                    try
+                    {
+                        bool useBom = WESettings.GetBoolean(WESettings.Keys.UseBom);
+                        using (StreamWriter writer = new StreamWriter(cssFileName, false, new UTF8Encoding(useBom)))
                         {
-                            bool useBom = WESettings.GetBoolean(WESettings.Keys.UseBom);
-                            using (StreamWriter writer = new StreamWriter(cssFileName, false, new UTF8Encoding(useBom)))
-                            {
-                                writer.Write(result.Result);
-                            }
+                            writer.Write(result.Result);
                         }
-                        catch (Exception ex)
+
+                        if (!cssFileExists)
                         {
-                            Logger.Log(ex);
+                            MarginBase.AddFileToProject(result.FileName, cssFileName);
                         }
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Log(ex);
                     }
                 }
 
@@ -96,20 +98,28 @@ namespace MadsKristensen.EditorExtensions
             {
                 string content = MinifyFileMenu.MinifyString(".css", source);
                 string minFile = MarginBase.GetCompiledFileName(lessFileName, ".min.css", WESettings.GetBoolean(WESettings.Keys.LessCompileToFolder)); //lessFileName.Replace(".less", ".min.css");
-                string old = File.ReadAllText(minFile);
-
-                if (old != content)
+                string old = string.Empty;
+                bool minFileExist = File.Exists(minFile);
+                if (minFileExist)
                 {
-                    bool fileExist = File.Exists(minFile);
+                    old = File.ReadAllText(minFile);                    
+                }
+
+                if (!minFileExist || old != content)
+                {
                     bool useBom    = WESettings.GetBoolean(WESettings.Keys.UseBom);
 
-                    ProjectHelpers.CheckOutFileFromSourceControl(minFile);
+                    if (minFileExist)
+                    {
+                        ProjectHelpers.CheckOutFileFromSourceControl(minFile);                        
+                    }
+
                     using (StreamWriter writer = new StreamWriter(minFile, false, new UTF8Encoding(useBom)))
                     {
                         writer.Write(content);
                     }
 
-                    if (!fileExist)
+                    if (!minFileExist)
                         MarginBase.AddFileToProject(lessFileName, minFile);
                 }
             }


### PR DESCRIPTION
Was having trouble with my team - we don't commit compiled or minified LESS to source control. When working individually on projects, we'd have to open all LESS files and use the save listener to re-create the .min.css and .css files in order for the LESS compilation to kick in and start checking these on build.

I think Issue #14 describes similar problems (although I didn't experience the crash).

There did seem to be some explicit checking for not compiling in these conditions (CanCompile function, Lines 41-49) so these changes may be unacceptable if there's a scenario I haven't considered here.
