### PR TITLE
Added support to .weignore

### DIFF
--- a/EditorExtensions/Commands/JavaScript/JsHintRunner.cs
+++ b/EditorExtensions/Commands/JavaScript/JsHintRunner.cs
@@ -2,6 +2,7 @@
 using Microsoft.VisualStudio.Shell;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -94,6 +95,12 @@ namespace MadsKristensen.EditorExtensions
                 {
                     return true;
                 }
+            }
+
+            if (MadsKristensen.EditorExtensions.WEIgnore.TestWEIgnore(file, "linter", "jshint"))
+            {
+                Logger.Log(String.Format(CultureInfo.CurrentCulture, "JsHint: The file {0} is ignored by .weignore. Skipping..", Path.GetFileName(file)));
+                return false;
             }
 
             return false;

--- a/EditorExtensions/EditorExtensions.csproj
+++ b/EditorExtensions/EditorExtensions.csproj
@@ -131,6 +131,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>$(DevEnvDir)\CommonExtensions\Microsoft\Web\Editor\Microsoft.Web.Editor.dll</HintPath>
     </Reference>
+    <Reference Include="Minimatch">
+      <HintPath>..\packages\Minimatch.1.1.0.0\lib\portable-net40+sl50+win+wp80\Minimatch.dll</HintPath>
+    </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />

--- a/EditorExtensions/EditorExtensions.csproj
+++ b/EditorExtensions/EditorExtensions.csproj
@@ -336,6 +336,7 @@
     <Compile Include="Options\TypeScript.cs">
       <SubType>Component</SubType>
     </Compile>
+    <Compile Include="Options\WEIgnore.cs" />
     <Compile Include="Validation\CSS\Filters\VariableCssErrorFilter.cs" />
     <Compile Include="Validation\LESS\Filters\LessAmpersandCssErrorFilter.cs" />
     <Compile Include="Validation\LESS\Filters\LessExtendCssErrorFilter.cs" />

--- a/EditorExtensions/Margin/CoffeeScriptMargin.cs
+++ b/EditorExtensions/Margin/CoffeeScriptMargin.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.VisualStudio.Text;
 using System;
+using System.Globalization;
 using System.IO;
 using System.Text;
 using System.Windows.Threading;
@@ -41,6 +42,12 @@ namespace MadsKristensen.EditorExtensions
 
                 if (!string.IsNullOrEmpty(fullPath))
                 {
+                    if (MadsKristensen.EditorExtensions.WEIgnore.TestWEIgnore(fullPath, "compiler", "coffeescript"))
+                    {
+                        Logger.Log(String.Format(CultureInfo.CurrentCulture, "CoffeeScript: The file {0} is ignored by .weignore. Skipping..", Path.GetFileName(fullPath)));
+                        return;
+                    }
+                    
                     string dir = Path.GetDirectoryName(fullPath);
                     var files = Directory.GetFiles(dir, "*.coffee", SearchOption.AllDirectories);
 

--- a/EditorExtensions/Margin/LessProjectCompiler.cs
+++ b/EditorExtensions/Margin/LessProjectCompiler.cs
@@ -1,5 +1,6 @@
 ﻿using EnvDTE;
 using System;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -37,6 +38,12 @@ namespace MadsKristensen.EditorExtensions
 
             if (Path.GetFileName(fileName).StartsWith("_"))
                 return false;
+
+            if (MadsKristensen.EditorExtensions.WEIgnore.TestWEIgnore(fileName, "compiler", "less"))
+            {
+                Logger.Log(String.Format(CultureInfo.CurrentCulture, "LESS: The file {0} is ignored by .weignore. Skipping..", Path.GetFileName(fileName)));
+                return false;
+            }
 
             string minFile = MarginBase.GetCompiledFileName(fileName, ".min.css", WESettings.GetBoolean(WESettings.Keys.LessCompileToFolder));
             if (File.Exists(minFile) && WESettings.GetBoolean(WESettings.Keys.LessMinify))

--- a/EditorExtensions/Options/WEIgnore.cs
+++ b/EditorExtensions/Options/WEIgnore.cs
@@ -1,0 +1,91 @@
+using System;
+using System.IO;
+using System.Linq;
+using Minimatch;
+using System.Diagnostics;
+
+namespace MadsKristensen.EditorExtensions
+{
+    public static class WEIgnore
+    {
+        public static bool TestWEIgnore(string sourcePath, string serviceToken, string serviceName)
+        {
+            string ignoreFile = GetIgnoreFile(Path.GetDirectoryName(sourcePath), ".weignore");
+
+            if (string.IsNullOrEmpty(ignoreFile))
+                return false;
+
+            string searchPattern;
+
+            using (StreamReader reader = File.OpenText(ignoreFile))
+            {
+                while ((searchPattern = reader.ReadLine()) != null)
+                {
+                    searchPattern = searchPattern.Trim();
+
+                    if (string.IsNullOrEmpty(searchPattern) || searchPattern.StartsWith("#", StringComparison.Ordinal))
+                        continue;
+
+                    int index = searchPattern.LastIndexOf('\t');
+
+                    if (index > 0)
+                    {
+                        string newPattern = searchPattern.Substring(0, index).Trim('\t');
+                        string[] subparts = searchPattern.Substring(++index, searchPattern.Length - index).Split(',')
+                                           .Select(p => p.Trim().ToLowerInvariant()).ToArray();
+
+                        if (subparts.Contains(serviceToken) || subparts.Contains(serviceName))
+                        {
+                            if (newPattern[0] == '!' &&
+                                new Minimatcher(newPattern.Substring(1), new Minimatch.Options { AllowWindowsPaths = true }).IsMatch(sourcePath))
+                                return false;
+                            else if (new Minimatcher(newPattern, new Minimatch.Options { AllowWindowsPaths = true }).IsMatch(sourcePath))
+                                return true;
+                        }
+                        else if (subparts.Contains("!" + serviceToken) || subparts.Contains("!" + serviceName))
+                        {
+                            if (newPattern[0] == '!' &&
+                                new Minimatcher(newPattern.Substring(1), new Minimatch.Options { AllowWindowsPaths = true }).IsMatch(sourcePath))
+                                return true;
+                            else if (new Minimatcher(newPattern, new Minimatch.Options { AllowWindowsPaths = true }).IsMatch(sourcePath))
+                                return false;
+                        }
+                        else // The rule is not applicable on this service, continue checking other rules.
+                            continue;
+
+                        searchPattern = newPattern;
+                    }
+
+                    if (searchPattern[0] == '!' &&
+                        new Minimatcher(searchPattern, new Minimatch.Options { AllowWindowsPaths = true }).IsMatch(sourcePath))
+                        return false;
+                    else if (new Minimatcher(searchPattern, new Minimatch.Options { AllowWindowsPaths = true }).IsMatch(sourcePath))
+                        return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static string GetIgnoreFile(string startDir, string settingsFileName)
+        {
+            while (!File.Exists(Path.Combine(startDir, settingsFileName)))
+            {
+                startDir = Path.GetDirectoryName(startDir);
+
+                if (String.IsNullOrEmpty(startDir))
+                    break;
+            }
+
+            if (String.IsNullOrEmpty(startDir))
+                startDir = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+
+            string fileName = Path.Combine(startDir, settingsFileName);
+
+            if (!File.Exists(fileName))
+                return null;
+
+            return fileName;
+        }
+    }
+}

--- a/EditorExtensions/packages.config
+++ b/EditorExtensions/packages.config
@@ -1,7 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AjaxMin" version="4.78.4724.23869" targetFramework="net45" />
-  <package id="AjaxMin" version="5.7.5124.21499" targetFramework="net45" />
+  <package id="AjaxMin" version="5.7.5124.21499" targetFramework="net45" />~
+  <package id="Minimatch" version="1.1.0" targetFramework="net45" />
   <package id="MarkdownSharp" version="1.13.0.0" targetFramework="net45" />
   <package id="VsixCompress" version="1.0.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This change provides support to file .weignore in WE2012.
Some of the code was borrowed from the WE2013 master (WEIgnore.cs).

I'm not using all features of WE, for that reason I may miss something.
Its working with LESS files, thats all I need for now :)
