### PR TITLE
Respect WESettings and WEIgnore when saving files.

### DIFF
--- a/EditorExtensions/Classifications/CSS/Base64TaggerProvider.cs
+++ b/EditorExtensions/Classifications/CSS/Base64TaggerProvider.cs
@@ -74,7 +74,11 @@ namespace MadsKristensen.EditorExtensions
             return _tree != null;
         }
 
-        public event EventHandler<SnapshotSpanEventArgs> TagsChanged;
+        public event EventHandler<SnapshotSpanEventArgs> TagsChanged
+        {
+            add { }
+            remove { }
+        }
 
         void BufferChanged(object sender, TextContentChangedEventArgs e)
         {

--- a/EditorExtensions/Completion/CSS/CompletionListEntry.cs
+++ b/EditorExtensions/Completion/CSS/CompletionListEntry.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Microsoft.CSS.Editor;
-using Microsoft.CSS.Editor;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Text;
 

--- a/EditorExtensions/Margin/CoffeeScriptMargin.cs
+++ b/EditorExtensions/Margin/CoffeeScriptMargin.cs
@@ -25,6 +25,20 @@ namespace MadsKristensen.EditorExtensions
             // Used for project compilation
         }
 
+        protected override bool CanCompileFileOnSave(string fullPath)
+        {
+            if (!WESettings.GetBoolean(WESettings.Keys.GenerateJsFileFromCoffeeScript))
+                return false;
+
+            if (MadsKristensen.EditorExtensions.WEIgnore.TestWEIgnore(fullPath, "compiler", "coffeescript"))
+            {
+                Logger.Log(String.Format(CultureInfo.CurrentCulture, "CoffeeScript: The file {0} is ignored by .weignore. Skipping..", Path.GetFileName(fullPath)));
+                return false;
+            }
+            else
+                return true;
+        }
+
         public void CompileProject(EnvDTE.Project project)
         {
             if(project == null)

--- a/EditorExtensions/Margin/LessMargin.cs
+++ b/EditorExtensions/Margin/LessMargin.cs
@@ -15,6 +15,20 @@ namespace MadsKristensen.EditorExtensions
             : base(source, MarginName, contentType, showMargin, document)
         { }
 
+        protected override bool CanCompileFileOnSave(string fullPath)
+        {
+            if (!WESettings.GetBoolean(WESettings.Keys.GenerateCssFileFromLess))
+                return false;
+
+            if (MadsKristensen.EditorExtensions.WEIgnore.TestWEIgnore(fullPath, "compiler", "less"))
+            {
+                Logger.Log(String.Format(CultureInfo.CurrentCulture, "LESS: The file {0} is ignored by .weignore. Skipping..", Path.GetFileName(fullPath)));
+                return false;
+            }
+            else
+                return true;
+        }
+
         protected override void StartCompiler(string source)
         {
             string fileName = GetCompiledFileName(Document.FilePath, ".css", UseCompiledFolder);// Document.FilePath.Replace(".less", ".css");

--- a/EditorExtensions/Margin/MarginBase.cs
+++ b/EditorExtensions/Margin/MarginBase.cs
@@ -29,6 +29,8 @@ namespace MadsKristensen.EditorExtensions
             _dispatcher = Dispatcher.CurrentDispatcher;
         }
 
+        protected abstract bool CanCompileFileOnSave(string path);
+
         protected MarginBase(string source, string name, string contentType, bool showMargin, ITextDocument document)
         {
             Document = document;
@@ -51,6 +53,9 @@ namespace MadsKristensen.EditorExtensions
         {
             if (e.FileActionType == FileActionTypes.ContentSavedToDisk)
             {
+                if (!CanCompileFileOnSave(e.FilePath))
+                    return;
+
                 _dispatcher.BeginInvoke(new Action(() =>
                 {
                     _provider.Tasks.Clear();

--- a/EditorExtensions/Margin/MarkdownMargin.cs
+++ b/EditorExtensions/Margin/MarkdownMargin.cs
@@ -35,6 +35,11 @@ namespace MadsKristensen.EditorExtensions
             }
         }
 
+        protected override bool CanCompileFileOnSave(string fullPath)
+        {
+            return true;
+        }
+
         protected override void StartCompiler(string source)
         {
             InitializeCompiler();

--- a/EditorExtensions/Margin/TypeScriptMargin.cs
+++ b/EditorExtensions/Margin/TypeScriptMargin.cs
@@ -15,6 +15,11 @@ namespace MadsKristensen.EditorExtensions
             SetupWatcher();
         }
 
+        protected override bool CanCompileFileOnSave(string fullPath)
+        {
+            return true;
+        }
+
         protected override void StartCompiler(string source)
         {
             if (_isFirstRun)

--- a/EditorExtensions/Source.extension.vsixmanifest
+++ b/EditorExtensions/Source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="5fb7364d-2e8c-44a4-95eb-2a382e30fec7" Version="3.7" Language="en-US" Publisher="Mads Kristensen" />
+    <Identity Id="5fb7364d-2e8c-44a4-95eb-2a382e30fec7" Version="3.9" Language="en-US" Publisher="Mads Kristensen" />
     <DisplayName>Web Essentials 2012</DisplayName>
     <Description xml:space="preserve">Adds many useful features to Visual Studio for web developers.</Description>
     <MoreInfo>http://vswebessentials.com/</MoreInfo>


### PR DESCRIPTION
All MarginBase classes should implement a method to check if the file
being saved by VS.TextEditor can be compiled.
